### PR TITLE
Forward SSH agent to pyicub-backend container

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -55,6 +55,7 @@ services:
       - NO_AT_BRIDGE=1
       - NVIDIA_VISIBLE_DEVICES=${GPU_DEVICES:-none}
       - NVIDIA_DRIVER_CAPABILITIES=all
+      - SSH_AUTH_SOCK=/ssh-agent
 
     command: ["/bin/bash", "-c", "bash ${WORKDIR:?error}/pyicub/scripts/start.sh"]
       
@@ -76,6 +77,9 @@ services:
       - /tmp/.X11-unix:/tmp/.X11-unix
       - ${HOME}/.config/pulse/cookie:/run/pulse/cookie
       - ${XDG_RUNTIME_DIR:?error}/pulse:${XDG_RUNTIME_DIR:?error}/pulse
+      - ${HOME}/.gitconfig:/root/.gitconfig:ro
+      - ${SSH_AUTH_SOCK:-/dev/null}:/ssh-agent
+      - ${HOME}/.ssh/known_hosts:/root/.ssh/known_hosts:ro
 
   pyicub.frontend:
     image: ${PYICUB_FRONTEND_IMAGE_NAME:?error}

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -79,7 +79,7 @@ services:
       - ${XDG_RUNTIME_DIR:?error}/pulse:${XDG_RUNTIME_DIR:?error}/pulse
       - ${HOME}/.gitconfig:/root/.gitconfig:ro
       - ${SSH_AUTH_SOCK:-/dev/null}:/ssh-agent
-      - ${HOME}/.ssh/known_hosts:/root/.ssh/known_hosts:ro
+      - ${HOME}/.ssh:/root/.ssh:ro
 
   pyicub.frontend:
     image: ${PYICUB_FRONTEND_IMAGE_NAME:?error}


### PR DESCRIPTION
In this PR, I fixed the SSH authentication issue by forwarding the host SSH agent to the container started by the pyicub-backend service.

The idea behind these changes is the following:

1. They allow the backend container to authenticate with GitHub using the SSH credentials already available on the host.

2. They make it possible to access  robots over SSH from within the backend container. 